### PR TITLE
update workflow name

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -3,7 +3,7 @@
 # Contains tests run by Galaxy-importer on Automation Hub.
 # For additional testing options, see
 # https://github.com/ansible-collections/certification#optional
-name: "cert"
+name: "Run collection certification checks"
 
 concurrency:
   group: cert-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
When added to a repository repo the name "cert" lacks meaning and can be difficult to find when there are more workflows under Actions. This changes the name to "Run collection certification checks" to be more obvious to users.