### PR TITLE
Fix issues from zizmor scan

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -5,6 +5,9 @@
 # https://github.com/ansible-collections/certification#optional
 name: "cert"
 
+permissions:
+  contents: read
+
 concurrency:
   group: cert-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -30,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Ensure ansible-core and galaxy-importer is installed
         shell: bash
@@ -61,6 +66,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -105,7 +112,7 @@ jobs:
       - name: Perform sanity testing
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e  # v1.17.0
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity


### PR DESCRIPTION
```
$ zizmor --persona=regular .github/workflows/
🌈 zizmor v1.16.3
 INFO audit: zizmor: 🌈 completed .github/workflows/certification.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/certification.yml:31:9
   |
31 |         - name: Checkout
   |  _________^
32 | |         uses: actions/checkout@v5
   | |_________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/certification.yml:62:9
   |
62 |         - name: Check out code
   |  _________^
63 | |         uses: actions/checkout@v2
   | |_________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/certification.yml:6:1
    |
  6 | / name: "cert"
  7 | |
  8 | | concurrency:
  9 | |   group: cert-${{ github.head_ref || github.run_id }}
...   |
123 | |           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
124 | |           pull-request-change-detection: false
    | |_______________________________________________^ default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/certification.yml:24:3
   |
24 | /   build-import:
25 | |     name: "Build & import collection"
26 | |     env:
27 | |       CHECK_REQUIRED_TAGS: "True"
...  |
55 | |   # Run ansible-lint with profile "production"
56 | |   # and skipping sanity checks as they run as a separate job
   | |                                                            ^
   | |                                                            |
   | |____________________________________________________________this job
   |                                                              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/certification.yml:57:3
   |
57 | /   lint:
58 | |     name: "Lint production"
59 | |     runs-on: ubuntu-latest
...  |
76 | |   # Run sanity checks against the collection
   | |                                            ^
   | |                                            |
   | |____________________________________________this job
   |                                              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/certification.yml:77:3
    |
 77 | /   sanity:
 78 | |     name: Sanity (Ⓐ${{ matrix.ansible }})
 79 | |     runs-on: ubuntu-latest
 80 | |     strategy:
...   |
123 | |           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
124 | |           pull-request-change-detection: false
    | |                                               ^
    | |                                               |
    | |_______________________________________________this job
    |                                                 default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/certification.yml:108:9
    |
108 |         uses: ansible-community/ansible-test-gh-action@release/v1
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

11 findings (4 suppressed, 2 fixable): 0 informational, 0 low, 6 medium, 1 high
```
