### PR TITLE
bump action versions

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -70,12 +70,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
```
$ podman run --rm --volume "$(pwd):/repo:Z" --workdir /repo rhysd/actionlint:latest -color
.github/workflows/certification.yml:63:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
63 |         uses: actions/checkout@v2
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/certification.yml:66:15: the runner of "actions/setup-python@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
66 |         uses: actions/setup-python@v2
   |               ^~~~~~~~~~~~~~~~~~~~~~~
```
