### PR TITLE
docs: migrate RTD URLs to docs.ansible.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some common reasons for certification rejections include:
 - Missing or unclear sections in the project README.
 Refer to the [Ansible Certified Collections README Template](https://access.redhat.com/articles/7068606) for all information that your README must contain.
 - Missing changelog entries for each collection version.
-We recommend using the [antsibull-changelog](https://ansible.readthedocs.io/projects/antsibull-changelog/) tool for changelog generation.
+We recommend using the [antsibull-changelog](https://docs.ansible.com/projects/antsibull-changelog/) tool for changelog generation.
 
 Additionally, certified collections must follow guidelines for dependency management such as:
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,5 +1,5 @@
 ---
-# See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
+# See https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html
 
 namespace: "ansible"
 name: "certification"


### PR DESCRIPTION
## Summary

This PR updates `readthedocs.io` URLs to their `docs.ansible.com` equivalents with proper anchor preservation.

## Changes (2 unique URLs, 2 files updated)

- https://ansible.readthedocs.io/projects/antsibull-changelog/ → https://docs.ansible.com/projects/antsibull-changelog/
- https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html → https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html

## Technical Details

- ✅ Anchor fragments preserved during URL transformations
- ✅ HTTP redirects followed to final destinations  
- ✅ URL validation completed before applying changes
- ✅ Configuration-driven URL mapping system

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>