### PR TITLE
add inputs to certification workflow

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -16,6 +16,33 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      ansible-core-version:
+        description: Version of ansible-core to use. Empty for latest.
+        required: false
+        type: string
+      ansible-lint-version:
+        description: Version of ansible-lint to use. Empty for latest.
+        required: false
+        type: string
+      galaxy-importer-version:
+        description: Version of galaxy-importer to use. Empty for latest.
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ansible-core-version:
+        description: Version of ansible-core to use. Empty for latest.
+        required: false
+        type: string
+      ansible-lint-version:
+        description: Version of ansible-lint to use. Empty for latest.
+        required: false
+        type: string
+      galaxy-importer-version:
+        description: Version of galaxy-importer to use. Empty for latest.
+        required: false
+        type: string
   # Below is an example cron scheduler,
   # tweak it as per your requirement
   schedule:
@@ -43,8 +70,21 @@ jobs:
 
       - name: Ensure ansible-core and galaxy-importer is installed
         shell: bash
+        env:
+          ANSIBLE_CORE: "${{ inputs.ansible-core-version || '' }}"
+          GALAXY_IMPORTER: "${{ inputs.galaxy-importer-version || '' }}"
         run: |
-          python -m pip install ansible-core galaxy-importer
+          if [ -n "$ANSIBLE_CORE" ]; then
+            python -m pip install "ansible-core==$ANSIBLE_CORE"
+          else
+            python -m pip install ansible-core
+          fi
+          
+          if [ -n "$GALAXY_IMPORTER" ]; then
+            python -m pip install "galaxy-importer==$GALAXY_IMPORTER"
+          else
+            python -m pip install galaxy-importer
+          fi
 
       - name: Update galaxy-importer.cfg
         shell: bash
@@ -80,7 +120,16 @@ jobs:
           python-version: "3.12"
 
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        shell: bash
+        env:
+          ANSIBLE_LINT: "${{ inputs.ansible-lint-version || '' }}"
+        run: |
+
+          if [ -n "$ANSIBLE_LINT" ]; then
+            pip install "ansible-lint==$ANSIBLE_LINT"
+          else
+            pip install ansible-lint
+          fi
 
       - name: Run ansible-lint
         run: ansible-lint --profile=production -x sanity

--- a/.github/workflows/test-certification-defaults.yml
+++ b/.github/workflows/test-certification-defaults.yml
@@ -1,4 +1,4 @@
-name: Test certification versioned
+name: Test certification defaults
 
 on:
   pull_request:
@@ -9,4 +9,4 @@ on:
 
 jobs:
   call:
-    uses: ./.github/workflows/certification-versioned.yml
+    uses: ./.github/workflows/certification.yml

--- a/.github/workflows/test-certification-inputs.yml
+++ b/.github/workflows/test-certification-inputs.yml
@@ -1,0 +1,16 @@
+name: Test certification inputs
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  call:
+    uses: ./.github/workflows/certification.yml
+    with:
+      ansible-core-version: '2.16.0'
+      ansible-lint-version: '24.12.2'
+      galaxy-importer-version: '0.4.31'


### PR DESCRIPTION
@Andersson007 This is what I was suggesting earlier. Maybe it still needs a bit of polishing but it seems to work well.

- Add workflow_call trigger to the certification workflow. This allows us to have a single workflow that can be either reusable or copied directly.
- Add inputs to the workflow_call and workflow_dispatch triggers. This allows to specify versions no matter if you choose the reusable approach or copy the workflow directly.
- Add the `|| '' ` operator to the inputs so that leaving them empty, not specifying a version, installs the latest version.

Perhaps we can give the Python version the same treatment, although we'd want to keep a sensible default. We could do that as a follow up. Same with the sanity test versions.

In any case I think it's better to try and keep it limited to a single workflow file. Otherwise maybe it gets confusing for partners. I'm also aware that there is a point where things will get too complex and we start moving away from the stated goal of a simple, straightforward workflow. If we give too much flexibility then maybe the results will become less reliable. Maybe we just want to make the workflow reusable without adding the versioning?