### PR TITLE
doc: update README.md

### DIFF
--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -1,7 +1,7 @@
 ---
 # This workflow runs the calling workflow from the main branch
 # in this repository for testing purposes.
-name: [main] Run collection certification checks
+name: (main) Run collection certification checks
 
 on:
   pull_request:

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -1,7 +1,7 @@
 ---
 # This workflow runs the calling workflow from the main branch
 # in this repository for testing purposes.
-name: Run collection certification checks
+name: [main] Run collection certification checks
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
     - cron: '0 6 * * *'
 
 concurrency:
-  group: cert-ver-${{ github.head_ref || github.run_id }}
+  group: cert-ver-main-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Additionally, certified collections must follow guidelines for dependency manage
 To run the certification checks against pull requests and on schedule:
 
 1. Copy the [Ansible collection certification GitHub Actions workflow](https://github.com/ansible-collections/certification/blob/main/.github/workflows/certification.yml) to the `.github/workflows` directory of your collection repository.
-1. Navigate to the `Actions` tab of the collection repository and then verify the workflow is enabled. 
-1. If Ansible Lint checks fail on files unrelated to the collection's core functionality, add an [.ansible-lint](.ansible-lint) file to your collection's root directory and list all files and directories you want Ansible Lint to ignore.
+1. Add the [.ansible-lint](.ansible-lint) file to your collection's root directory and list all files and directories you want Ansible Lint to ignore to avoid failures on files unrelated to the collection's core functionality. Commit and push the changes to your upstream repository on GitHub.
+1. Navigate to the `Actions` tab of the repository and then verify the workflow is enabled. 
 1. If there are sanity test failures that cannot be fixed and are [allowed to ignore](https://docs.ansible.com/projects/lint/rules/sanity/), create a [sanity ignore file](https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location) for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 
 ### Updating the test matrix

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally, certified collections must follow guidelines for dependency manage
 To run the certification checks against pull requests and on schedule:
 
 1. Copy the [Ansible collection certification GitHub Actions workflow](https://github.com/ansible-collections/certification/blob/main/.github/workflows/certification.yml) to the `.github/workflows` directory of your collection repository.
-1. Add the [.ansible-lint](.ansible-lint) file to your collection's root directory and list all files and directories you want Ansible Lint to ignore to avoid failures on files unrelated to the collection's core functionality. Commit and push the changes to your upstream repository on GitHub.
+1. Add an [.ansible-lint](.ansible-lint) configuration file to the root directory of your collection. List any files and folders that are not related to the collection's core functionality, such as `.github/`, so that Ansible Lint does not warn about violations in those files and folders. Commit and push the changes to your upstream repository on GitHub.
 1. Navigate to the `Actions` tab of the repository and then verify the workflow is enabled. 
 1. If there are sanity test failures that cannot be fixed and are [allowed to ignore](https://docs.ansible.com/projects/lint/rules/sanity/), create a [sanity ignore file](https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location) for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 


### PR DESCRIPTION
##### SUMMARY
doc: update README.md

I've changed this "If" to "Add" because after adding the workflow to a few collections, .ansible-lint was always necessary coz there were always lint failures on unrelated files