### PR TITLE
feat: add ansible_core_version variable

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -11,6 +11,12 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      ansible_core_version:
+        description: "ansible-core version for sanity testing (e.g. stable-2.16)"
+        default: "stable-2.16"
+        required: false
+        type: string
 
 jobs:
   # Build the collection and run galaxy-importer on it
@@ -92,7 +98,7 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.16
+          - ${{ inputs.ansible_core_version }}
         python:
           - '3.6'
           - '3.7'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -18,4 +18,4 @@ jobs:
   call:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
     with:
-      ansible_core_version: 'stable-2.17'
+      ansible-core-version: 'stable-2.17'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -1,7 +1,7 @@
 ---
 # This workflow runs the calling workflow from the main branch
 # in this repository for testing purposes.
-name: Run collection certification checks
+name: (main) Run collection certification checks
 
 on:
   pull_request:
@@ -11,11 +11,11 @@ on:
     - cron: '0 6 * * *'
 
 concurrency:
-  group: cert-ver-${{ github.head_ref || github.run_id }}
+  group: cert-ver-main-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   call:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
     with:
-      ansible-core-version: 'stable-2.17'
+      ansible_core_version: 'stable-2.17'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -17,3 +17,5 @@ concurrency:
 jobs:
   call:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    with:
+      ansible_core_version: 'stable-2.17'


### PR DESCRIPTION
##### SUMMARY
feat: add ansible_core_version variable

the idea is to allow collections specify core versions older than 2.16 if they don't support it