### PR TITLE
feat: add variable to pass core version

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -19,6 +19,13 @@ on:
         required: false
         default: '2.16.0'
         type: string
+      python-versions:
+        description: >-
+          JSON list of Python versions to test against in the sanity matrix
+          (e.g. '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]').
+        required: false
+        default: '["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+        type: string
 
 jobs:
   # Derive stable-X.Y from the ansible-core-version input for use in the
@@ -115,14 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
+        python: ${{ fromJSON(inputs.python-versions) }}
 
     steps:
       # Run sanity tests inside a Docker container.

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -11,8 +11,31 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      ansible-core-version:
+        description: >-
+          ansible-core version to use (e.g. 2.16.0).
+          The stable-X.Y branch is derived automatically for sanity tests.
+        required: false
+        default: '2.16.0'
+        type: string
 
 jobs:
+  # Derive stable-X.Y from the ansible-core-version input for use in the
+  # sanity matrix, since GitHub Actions expressions cannot slice strings.
+  compute-versions:
+    name: "Compute versions"
+    runs-on: ubuntu-latest
+    outputs:
+      stable-ansible: ${{ steps.compute.outputs.stable-ansible }}
+    steps:
+      - name: Derive stable-X.Y from ansible-core-version
+        id: compute
+        run: |
+          version="${{ inputs.ansible-core-version }}"
+          major_minor=$(echo "${version}" | cut -d. -f1,2)
+          echo "stable-ansible=stable-${major_minor}" >> "${GITHUB_OUTPUT}"
+
   # Build the collection and run galaxy-importer on it
   # skipping ansible-lint as it runs as a separate job
   build-import:
@@ -20,7 +43,7 @@ jobs:
     env:
       CHECK_REQUIRED_TAGS: "True"
       RUN_ANSIBLE_LINT: "False"
-      CORE_VER: "2.16.0"
+      CORE_VER: ${{ inputs.ansible-core-version }}
       GALAXY_IMPORTER_VER: "0.4.31"
     runs-on: ubuntu-latest
     steps:
@@ -62,7 +85,7 @@ jobs:
     name: "Lint production"
     runs-on: ubuntu-latest
     env:
-      CORE_VER: "2.16.0"
+      CORE_VER: ${{ inputs.ansible-core-version }}
       LINT_VER: "24.12.2"
 
     steps:
@@ -87,12 +110,11 @@ jobs:
 
   # Run sanity checks against the collection
   sanity:
-    name: Sanity (Ⓐ${{ matrix.ansible }}, Python ${{ matrix.python }})
+    needs: compute-versions
+    name: Sanity (Ⓐ${{ needs.compute-versions.outputs.stable-ansible }}, Python ${{ matrix.python }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible:
-          - stable-2.16
         python:
           - '3.6'
           - '3.7'
@@ -111,7 +133,7 @@ jobs:
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
         uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e  # v1.17.0
         with:
-          ansible-core-version: ${{ matrix.ansible }}
+          ansible-core-version: ${{ needs.compute-versions.outputs.stable-ansible }}
           testing-type: sanity
           target-python-version: ${{ matrix.python }}
           # Uncomment to configure a codecov token.

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -33,3 +33,7 @@ concurrency:
 jobs:
   call:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1
+    # If the minimal Ansible Core version your collection supports Ansible
+    # is greater than 2.16.0, specify it below.
+    # with:
+    #   ansible-core-version: '2.17.0'

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -35,5 +35,8 @@ jobs:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
+    # You might also have to specify Python version supported by that version,
+    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
     # with:
     #   ansible-core-version: '2.17.0'
+    #   python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -15,5 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  call:
+  # Test with the default ansible-core version (currently 2.16.0)
+  call-default:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+
+  # Test with ansible-core 2.17.x
+  call-2-17:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    with:
+      ansible-core-version: '2.17.1'
+
+  # Test with ansible-core 2.18.x
+  call-2-18:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    with:
+      ansible-core-version: '2.18.0'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -17,16 +17,16 @@ concurrency:
 jobs:
   # Test with the default ansible-core version (currently 2.16.0)
   call-default:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    uses: ./.github/workflows/certification-reusable.yml
 
   # Test with ansible-core 2.17.x
   call-2-17:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    uses: ./.github/workflows/certification-reusable.yml
     with:
       ansible-core-version: '2.17.1'
 
   # Test with ansible-core 2.18.x
   call-2-18:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    uses: ./.github/workflows/certification-reusable.yml
     with:
       ansible-core-version: '2.18.0'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -16,17 +16,20 @@ concurrency:
 
 jobs:
   # Test with the default ansible-core version (currently 2.16.0)
+  # and default min Python version (3.6)
   call-default:
     uses: ./.github/workflows/certification-reusable.yml
 
-  # Test with ansible-core 2.17.x
+  # Test with ansible-core 2.17.x; Python 3.6 is not supported from this version
   call-2-17:
     uses: ./.github/workflows/certification-reusable.yml
     with:
       ansible-core-version: '2.17.1'
+      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
 
-  # Test with ansible-core 2.18.x
+  # Test with ansible-core 2.18.x; Python 3.6 is not supported from this version
   call-2-18:
     uses: ./.github/workflows/certification-reusable.yml
     with:
       ansible-core-version: '2.18.0'
+      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -32,4 +32,4 @@ jobs:
     uses: ./.github/workflows/certification-reusable.yml
     with:
       ansible-core-version: '2.18.0'
-      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+      python-versions: '["3.8", "3.9", "3.10", "3.11", "3.12"]'


### PR DESCRIPTION
##### SUMMARY
feat: add variable to pass core version and Python versions relevant for a custom version. The default is 2.16 if not specified.

Context: in a collection with required_ansible >= 2.17.0 and higher we see errors https://github.com/Andersson007/amazon.aws/pull/1

For Python var the string is used because: "GitHub Actions workflow_call inputs only support three scalar types: string, boolean, and number. There is no array type. This is a hard GitHub Actions limitation, not a YAML one." I checked on the internet and it seems relevant. So we have to pass strings between WFs...