### PR TITLE
Validate galaxy.yml dependencies are defined in a requirements.yml file

### DIFF
--- a/.github/scripts/validate_collection_dependencies.py
+++ b/.github/scripts/validate_collection_dependencies.py
@@ -1,0 +1,94 @@
+"""Validate that galaxy.yml dependencies are listed in requirements.yml.
+
+When a collection declares dependencies in galaxy.yml, ansible-lint needs a
+requirements.yml file to discover and install those dependencies. This script
+checks for that and gives a clear, actionable error message before ansible-lint
+runs.
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate that galaxy.yml dependencies are listed in requirements.yml.",
+    )
+    parser.add_argument(
+        "collection_root",
+        nargs="?",
+        default=".",
+        help="Path to the collection root directory (where galaxy.yml lives). Defaults to '.'",
+    )
+    args = parser.parse_args()
+    collection_root = args.collection_root
+
+    galaxy_path = os.path.join(collection_root, "galaxy.yml")
+    requirements_path = os.path.join(collection_root, "requirements.yml")
+
+    if not os.path.isfile(galaxy_path):
+        print(f"ERROR: {galaxy_path} not found.")
+        sys.exit(1)
+
+    with open(galaxy_path) as f:
+        galaxy = yaml.safe_load(f)
+
+    deps = galaxy.get("dependencies") or {}
+    if not deps:
+        print(
+            f"No dependencies declared in {galaxy_path}, skipping requirements.yml check."
+        )
+        return
+
+    print(f"Found {len(deps)} dependency(ies) in {galaxy_path}: {list(deps.keys())}")
+
+    if not os.path.isfile(requirements_path):
+        print(
+            f"ERROR: {requirements_path} not found but {galaxy_path} declares dependencies."
+        )
+        for dep in deps:
+            print(
+                f"  - Collection '{dep}' is listed as a dependency in "
+                f"{galaxy_path} but there is no requirements.yml file."
+            )
+        print(
+            "\nAll collection dependencies must be listed in "
+            f"{requirements_path} so that ansible-lint can discover "
+            "and install them."
+        )
+        sys.exit(1)
+
+    with open(requirements_path) as f:
+        reqs = yaml.safe_load(f) or {}
+
+    req_collections = set()
+    for entry in reqs.get("collections") or []:
+        if isinstance(entry, str):
+            req_collections.add(entry)
+        elif isinstance(entry, dict) and "name" in entry:
+            req_collections.add(entry["name"])
+
+    missing = [dep for dep in deps if dep not in req_collections]
+
+    if missing:
+        print(
+            f"ERROR: The following dependencies from {galaxy_path} are "
+            f"missing from {requirements_path}:"
+        )
+        for dep in missing:
+            print(f"  - {dep}")
+        print(
+            "\nAll collection dependencies must be listed in "
+            f"{requirements_path} so that ansible-lint can discover "
+            "and install them."
+        )
+        sys.exit(1)
+
+    print(f"All {galaxy_path} dependencies are present in {requirements_path}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -31,7 +31,7 @@ on:
           Path to the collection root directory (where galaxy.yml lives).
           Defaults to the repository root.
         required: false
-        default: '.'
+        default: "."
         type: string
 
 jobs:
@@ -126,6 +126,8 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .partner-certification-checker
           sparse-checkout: .github/scripts
+          # Ensure we only check out the above directory
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Validate collection dependencies are in requirements.yml

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -17,7 +17,7 @@ on:
           ansible-core version to use (e.g. 2.16.0).
           The stable-X.Y branch is derived automatically for sanity tests.
         required: false
-        default: '2.16.0'
+        default: "2.16.0"
         type: string
       python-versions:
         description: >-
@@ -25,6 +25,13 @@ on:
           (e.g. '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]').
         required: false
         default: '["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+        type: string
+      collection-root:
+        description: >-
+          Path to the collection root directory (where galaxy.yml lives).
+          Defaults to the repository root.
+        required: false
+        default: '.'
         type: string
 
 jobs:
@@ -112,6 +119,18 @@ jobs:
       - name: Install ansible-lint
         run: pip install ansible-lint==${{ env.LINT_VER }}
 
+      - name: Checkout validation scripts
+        uses: actions/checkout@v6
+        with:
+          repository: ansible-collections/partner-certification-checker
+          ref: ${{ github.workflow_sha }}
+          path: .partner-certification-checker
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Validate collection dependencies are in requirements.yml
+        run: python .partner-certification-checker/.github/scripts/validate_collection_dependencies.py ${{ inputs.collection-root }}
+
       - name: Run ansible-lint
         run: ansible-lint --profile=production -x sanity
 
@@ -131,7 +150,7 @@ jobs:
       - name: Perform sanity testing
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e  # v1.17.0
+        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e # v1.17.0
         with:
           ansible-core-version: ${{ needs.compute-versions.outputs.stable-ansible }}
           testing-type: sanity

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -125,13 +125,19 @@ jobs:
           repository: ansible-collections/partner-certification-checker
           ref: ${{ github.workflow_sha }}
           path: .partner-certification-checker
-          sparse-checkout: .github/scripts
+          sparse-checkout: noxfile.py
           # Ensure we only check out the above directory
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
+      - name: Setup nox
+        uses: wntrblm/nox@2026.02.09
+        with:
+          python-versions: "3.12"
+
       - name: Validate collection dependencies are in requirements.yml
-        run: python .partner-certification-checker/.github/scripts/validate_collection_dependencies.py ${{ inputs.collection-root }}
+        run: nox -s validate_dependencies -- ${{ inputs.collection-root }}
+        working-directory: .partner-certification-checker
 
       - name: Run ansible-lint
         run: ansible-lint --profile=production -x sanity

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,71 @@
+"""Nox sessions for partner-certification-checker automation."""
+
+from pathlib import Path
+
+import nox
+import yaml
+
+
+@nox.session
+def validate_dependencies(session: nox.Session):
+    """Validate that galaxy.yml dependencies are listed in requirements.yml.
+
+    When a collection declares dependencies in galaxy.yml, ansible-lint needs a
+    requirements.yml file to discover and install those dependencies. This session
+    checks for that and gives a clear, actionable error message before ansible-lint
+    runs.
+
+    Usage:
+        nox -s validate_dependencies              # Check current directory
+        nox -s validate_dependencies -- /path     # Check specific directory
+    """
+    # Get collection_root from posargs, default to "."
+    collection_root = Path(session.posargs[0] if session.posargs else ".")
+
+    galaxy_path = collection_root / "galaxy.yml"
+    requirements_path = collection_root / "requirements.yml"
+
+    if not galaxy_path.is_file():
+        session.error(f"ERROR: {galaxy_path} not found.")
+
+    galaxy = yaml.safe_load(galaxy_path.read_text(encoding="utf-8"))
+
+    deps = galaxy.get("dependencies", {})
+    if not deps:
+        return
+
+    print(f"Validating {len(deps)} collection dependencies")
+
+    if not requirements_path.is_file():
+        deps_list = "\n".join(
+            f"  - Collection '{dep}' is listed as a dependency in {galaxy_path} "
+            f"but there is no requirements.yml file."
+            for dep in deps
+        )
+        session.error(
+            f"ERROR: {requirements_path} not found but {galaxy_path} declares dependencies.\n"
+            f"{deps_list}\n\n"
+            f"All collection dependencies must be listed in {requirements_path} "
+            f"so that ansible-lint can discover and install them."
+        )
+
+    reqs = yaml.safe_load(requirements_path.read_text(encoding="utf-8")) or {}
+
+    req_collections = {
+        entry if isinstance(entry, str) else entry["name"]
+        for entry in reqs.get("collections", [])
+        if isinstance(entry, str) or (isinstance(entry, dict) and "name" in entry)
+    }
+
+    missing = set(deps) - req_collections
+
+    if missing:
+        deps_list = "\n".join(f"  - {dep}" for dep in missing)
+        session.error(
+            f"ERROR: The following dependencies from {galaxy_path} "
+            f"are missing from {requirements_path}:\n{deps_list}\n\n"
+            f"All collection dependencies must be listed in {requirements_path} "
+            f"so that ansible-lint can discover and install them."
+        )
+
+    print("✓ All dependencies validated")


### PR DESCRIPTION
## Summary
- Adds a `validate_collection_dependencies.py` script that checks all `galaxy.yml` dependencies are listed in `requirements.yml`, with graceful error handling for missing files.
- Adds a new optional `collection-root` workflow input so partners whose collection root differs from the repo root (e.g. monorepo layouts) can specify the path where `galaxy.yml` lives. Defaults to `.` (repository root) for backwards compatibility.
- Passes the `collection-root` input to the validation script in the reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)