### PR TITLE
feat: add nox sessions for actionlint and zizmor checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: Certification checker CI
 
 "on":
@@ -28,11 +29,11 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@5a277b752f6094150e25237d47c34168e2b7526e #2026.02.09
+        uses: wntrblm/nox@5a277b752f6094150e25237d47c34168e2b7526e # 2026.02.09
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: "Run nox -e ${{ matrix.session }}"
@@ -49,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+name: Certification checker CI
+
+"on":
+  schedule:
+    # Daily
+    - cron: "23 7 * * *"
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nox:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Inputs:
+          #   session: name of session
+          #   python-versions: comma-separated list of Python versions to install
+          - session: "actionlint"
+            python-versions: "3.12"
+          - session: "zizmor"
+            python-versions: "3.12"
+    name: "Run nox ${{ matrix.session }} session"
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup nox
+        uses: wntrblm/nox@2026.02.09
+        with:
+          python-versions: "${{ matrix.python-versions }}"
+      - name: "Run nox -e ${{ matrix.session }}"
+        # zizmor: ignore[template-injection]
+        run: |
+          nox -e "${{ matrix.session }}"
+
+  check:
+    if: always()
+
+    needs:
+      - nox
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,11 +28,11 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2026.02.09
+        uses: wntrblm/nox@5a277b752f6094150e25237d47c34168e2b7526e #2026.02.09
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: "Run nox -e ${{ matrix.session }}"
@@ -50,6 +50,6 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,16 +26,19 @@ jobs:
             python-versions: "3.12"
           - session: "zizmor"
             python-versions: "3.12"
+
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup nox
         uses: wntrblm/nox@5a277b752f6094150e25237d47c34168e2b7526e # 2026.02.09
         with:
           python-versions: "${{ matrix.python-versions }}"
+
       - name: "Run nox -e ${{ matrix.session }}"
         # zizmor: ignore[template-injection]
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import nox
+
+CONTAINER_ENGINES = ("podman", "docker")
+CHOSEN_CONTAINER_ENGINE = os.environ.get("CONTAINER_ENGINE")
+ACTIONLINT_IMAGE = "docker.io/rhysd/actionlint"
+
+
+def _get_container_engine(session: nox.Session) -> str:
+    path: str | None = None
+    if CHOSEN_CONTAINER_ENGINE:
+        path = shutil.which(CHOSEN_CONTAINER_ENGINE)
+        if not path:
+            session.error(
+                f"CONTAINER_ENGINE {CHOSEN_CONTAINER_ENGINE!r} does not exist!"
+            )
+        return path
+    for engine in CONTAINER_ENGINES:
+        if path := shutil.which(engine):
+            return path
+    session.error(
+        f"None of the following container engines were found: {CONTAINER_ENGINES}."
+        f" {session.name} requires a container engine installed."
+    )
+
+
+@nox.session
+def actionlint(session: nox.Session) -> None:
+    """
+    Run actionlint to lint Github Actions workflows.
+    The actionlint tool is run in a Podman/Docker container.
+    """
+    engine = _get_container_engine(session)
+    session.run_always(engine, "pull", ACTIONLINT_IMAGE, external=True)
+    session.run(
+        engine,
+        "run",
+        "--rm",
+        # fmt: off
+        "--volume", f"{Path.cwd()}:/pwd:z",
+        "--workdir", "/pwd",
+        # fmt: on
+        ACTIONLINT_IMAGE,
+        *session.posargs,
+        external=True,
+    )
+
+
+@nox.session
+def zizmor(session: nox.Session) -> None:
+    """
+    Run zizmor, a Github Actions security checker
+    """
+    args: list[str] = list(session.posargs)
+    if not any(a.startswith("--persona") for a in args):
+        args.append("--persona=regular")
+    session.install("zizmor")
+    session.run("zizmor", *args, ".github/workflows")


### PR DESCRIPTION
##### SUMMARY
This change adds CI checks for actionlint and zizmor using a noxfile that can also run locally.

I've borrowed extensively from the noxfile and CI workflow in https://github.com/ansible/ansible-documentation That work was done by @gotmax23 and @felixfontein who I have mentioned as co-authors in the commit.

##### ISSUE TYPE
- Feature Pull Request