### PR TITLE
update certification workflows to comply with zizmor rules

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -100,12 +100,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -38,8 +38,10 @@ jobs:
     steps:
       - name: Derive stable-X.Y from ansible-core-version
         id: compute
+        env:
+          ANSIBLE_CORE_VERSION: ${{ inputs.ansible-core-version }}
         run: |
-          version="${{ inputs.ansible-core-version }}"
+          version="${ANSIBLE_CORE_VERSION}"
           major_minor=$(echo "${version}" | cut -d. -f1,2)
           echo "stable-ansible=stable-${major_minor}" >> "${GITHUB_OUTPUT}"
 
@@ -55,17 +57,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install ansible-core
-        run: pip install ansible-core==${{ env.CORE_VER }}
+        env:
+          CORE_VER: ${{ inputs.ansible-core-version }}
+        run: pip install ansible-core==${CORE_VER}
 
       - name: Install galaxy-importer
         shell: bash
@@ -92,22 +96,23 @@ jobs:
     name: "Lint production"
     runs-on: ubuntu-latest
     env:
-      CORE_VER: ${{ inputs.ansible-core-version }}
       LINT_VER: "24.12.2"
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install ansible-core
-        run: pip install ansible-core==${{ env.CORE_VER }}
+        env:
+          CORE_VER: ${{ inputs.ansible-core-version }}
+        run: pip install ansible-core==${CORE_VER}
 
       - name: Install ansible-lint
         run: pip install ansible-lint==${{ env.LINT_VER }}

--- a/.github/workflows/certification-static.yml
+++ b/.github/workflows/certification-static.yml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -77,12 +77,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/certification-static.yml
+++ b/.github/workflows/certification-static.yml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.12"
 
@@ -77,12 +77,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -6,6 +6,9 @@
 # Automation Hub tests.
 name: Run collection certification checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]
@@ -32,7 +35,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@a930fadb8b6799461bbbbce27b669f83e877fafa # v0.1
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -3,6 +3,9 @@
 # in this repository for testing purposes.
 name: (main) Run collection certification checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -2,6 +2,10 @@
 # This workflow runs the reusable workflow
 # in this repository for testing purposes.
 name: Test certification-reusable workflow
+
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
pin actions to hash and prevent potential shell expansion

##### SUMMARY
Follows up on https://github.com/ansible-collections/partner-certification-checker/pull/50 to address issues found with zizmor scan.

##### ISSUE TYPE
- Bugfix Pull Request