### PR TITLE
Update .ansible-lint: add extensions/molecule to exclude_paths

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,4 @@ exclude_paths:
   - changelogs/
   - tests/
   - meta/
+  - extensions/molecule


### PR DESCRIPTION
Update .ansible-lint: add extensions/molecule to exclude_paths

##### SUMMARY
As was suggested in https://github.com/ansible-collections/partner-certification-checker/pull/49#issuecomment-4047538256