### PR TITLE
Wrap var in double quotes for actionlint

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install ansible-core
         env:
           CORE_VER: ${{ inputs.ansible-core-version }}
-        run: pip install ansible-core==${CORE_VER}
+        run: pip install ansible-core=="${CORE_VER}"
 
       - name: Install galaxy-importer
         shell: bash
@@ -112,7 +112,7 @@ jobs:
       - name: Install ansible-core
         env:
           CORE_VER: ${{ inputs.ansible-core-version }}
-        run: pip install ansible-core==${CORE_VER}
+        run: pip install ansible-core=="${CORE_VER}"
 
       - name: Install ansible-lint
         run: pip install ansible-lint==${{ env.LINT_VER }}


### PR DESCRIPTION
Double quote to prevent globbing and word splitting

##### SUMMARY
.github/workflows/certification-reusable.yml:72:9: shellcheck reported issue in this script: SC2086:info:1:27: Double quote to prevent globbing and word splitting [shellcheck]
   |
72 |         run: pip install ansible-core==${CORE_VER}
   |         ^~~~
.github/workflows/certification-reusable.yml:115:9: shellcheck reported issue in this script: SC2086:info:1:27: Double quote to prevent globbing and word splitting [shellcheck]
    |
115 |         run: pip install ansible-core==${CORE_VER}
    |         ^~~~


##### ISSUE TYPE
- Bugfix Pull Request

Relates to https://github.com/ansible-collections/partner-certification-checker/pull/50 and follows up on https://github.com/ansible-collections/partner-certification-checker/pull/51