### PR TITLE
refactor(certification.yml): use version instead of sha to call reusable workflow

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -34,7 +34,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@e42f3db52af82579b1888fded50072a9c190af87 # v1.1.0
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v1.1.0 # zizmor: ignore[unpinned-uses]
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/partner-certification-checker/issues/65