### PR TITLE
docs(RELEASING.md,certification.yml): use immutable releases

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,9 +1,12 @@
 ---
-# This workflow calls the latest version of the
-# reusable workflow.
-# You can copy this file into your respository if
-# you want to check against pinned versions of
-# Automation Hub tests.
+# This workflow calls a pinned version of the
+# reusable workflow. Copy this file into your
+# repository to check against pinned versions
+# of Automation Hub tests.
+# The version is pinned to an exact release tag
+# (e.g. @v1.2.0) for supply chain security.
+# Use Dependabot to receive automatic PRs when
+# new versions are released.
 name: Run collection certification checks
 
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ Enable **Immutable releases** in the repository settings under **Settings > Code
    git tag -a vX.Y.Z -m "Release vX.Y.Z"
    git push origin vX.Y.Z
    ```
-4. Create a **GitHub Release** from that tag. The release becomes immutable once published.
+4. Create a **GitHub Release** from that tag. The release is immutable when published.
 5. For v1.x releases only, update the floating `v1` tag to point to the new release.
    ```bash
    git tag -f v1 vX.Y.Z

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,7 @@ Enable **Immutable releases** in the repository settings under **Settings > Code
    git push origin vX.Y.Z
    ```
 4. Create a **GitHub Release** from that tag. The release becomes immutable once published.
-5. For v1.x releases only, update the floating `v1` tag to point to the new release:
+5. For v1.x releases only, update the floating `v1` tag to point to the new release.
    ```bash
    git tag -f v1 vX.Y.Z
    git push upstream -f v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,13 @@ When updating versions of tools in the reusable workflow, ensure that the change
 
 For example, when bumping the `ansible-core` version from `2.16` to `2.17`, create a corresponding changelog fragment. It should note that, because workflow version N runs the `ansible-test sanity` command from ansible-core 2.17, if a partner has a `tests/sanity/ignore-2.16.txt` file, they need to copy it to `tests/sanity/ignore-2.17.txt` to prevent errors.
 
+## Immutable releases
+
+This repository uses [GitHub Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) to protect supply chain integrity.
+Once a GitHub Release is published, its tag cannot be moved or deleted.
+
+Enable **Immutable releases** in the repository settings under **Settings > Code security > Immutable releases** (this only needs to be done once).
+
 ## Release process
 
 1. Based on the [Semantic Versioning](https://semver.org/) conventions and [changelog/fragments](changelog/fragments), determine a proper release version number.
@@ -17,13 +24,28 @@ For example, when bumping the `ansible-core` version from `2.16` to `2.17`, crea
    - When we change any versions of tools, their arguments or anything else that might result in failures on partners' side, we release a major version.
    - If this is the case, make sure there's a corresponding changelog entry containing a porting guide as explained in the [Changelog](#changelog) section.
 2. Follow the [Releasing guidelines](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_release_without_branches.html) where applicable (for example, we don't publish this collection on Galaxy).
-3. When releasing a major release, besides a tag for the release `X.y.z`, also create a corresponding tag `vX` that will always point to the latest release of this major release. For example, if you released version `1.0.0`, create tag `v1` that will point to the same commit as tag `v1.0.0`.
-4. When releasing a minor or patch release `x.Y.Z`, move a corresponding `vX` tag to point to it. For example, when releasing version `1.1.0`, move tag `v1` to point to the same commit as `v1.1.0`.
+3. Create an annotated tag and push it:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+4. Create a **GitHub Release** from that tag. The release becomes immutable once published.
+5. For v1.x releases only, update the floating `v1` tag to point to the new release:
+   ```bash
+   git tag -f v1 vX.Y.Z
+   git push upstream -f v1
+   ```
+6. Update the version reference in the [calling workflow](.github/workflows/certification.yml) to `@vX.Y.Z` and open a PR.
 
-   1. Get the commit SHA for the tag: `git rev-parse v1.1.0`
-   2. Move the existing local `v1` tag to the new commit SHA: `git tag -f v1 <commit-sha-of-v1.1.0>`
-   3. Force push the tag to GitHub: `git push upstream -f v1`
-5. Update the release part in the [calling workflow](.github/workflows/certification.yml) if needed, for example, `@v1` -> `v2` so that new users copy its latest version.
+### Floating tag transition plan
+
+The `v1` floating tag is kept for backwards compatibility with users who referenced `@v1` in their workflows.
+
+When `v2.0.0` is released:
+
+- Freeze the `v1` tag at its last v1.x release (stop updating it).
+- **Do NOT create a floating `v2` tag.** All v2+ users must use exact version pins only.
+- Exact version pins combined with immutable releases ensure that a published release cannot be tampered with. Users can use [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to receive automatic pull requests when new versions are released.
 
 ## Post-release actions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ For example, when bumping the `ansible-core` version from `2.16` to `2.17`, crea
 ## Immutable releases
 
 This repository uses [GitHub Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) to protect supply chain integrity.
-Once a GitHub Release is published, its tag cannot be moved or deleted.
+When a release is published, that release tag cannot be moved or deleted.
 
 Enable **Immutable releases** in the repository settings under **Settings > Code security > Immutable releases** (this only needs to be done once).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,7 @@ Enable **Immutable releases** in the repository settings under **Settings > Code
    - When we change any versions of tools, their arguments or anything else that might result in failures on partners' side, we release a major version.
    - If this is the case, make sure there's a corresponding changelog entry containing a porting guide as explained in the [Changelog](#changelog) section.
 2. Follow the [Releasing guidelines](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_release_without_branches.html) where applicable (for example, we don't publish this collection on Galaxy).
-3. Create an annotated tag and push it:
+3. Create an annotated tag and push it.
    ```bash
    git tag -a vX.Y.Z -m "Release vX.Y.Z"
    git push origin vX.Y.Z

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ For example, when bumping the `ansible-core` version from `2.16` to `2.17`, crea
 This repository uses [GitHub Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) to protect supply chain integrity.
 When a release is published, that release tag cannot be moved or deleted.
 
-Enable **Immutable releases** in the repository settings under **Settings > Code security > Immutable releases** (this only needs to be done once).
+Enable **Immutable releases** in the repository settings under **Settings > Code security > Immutable releases**. You need to do this one time only.
 
 ## Release process
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,7 @@ The `v1` floating tag is kept for backwards compatibility with users who referen
 
 When `v2.0.0` is released:
 
-- Freeze the `v1` tag at its last v1.x release (stop updating it).
+- Freeze the `v1` tag at its last v1.x release so that it can no longer be updated.
 - **Do NOT create a floating `v2` tag.** All v2+ users must use exact version pins only.
 - Exact version pins combined with immutable releases ensure that a published release cannot be tampered with. Users can use [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to receive automatic pull requests when new versions are released.
 


### PR DESCRIPTION
##### SUMMARY
docs(RELEASING.md,certification.yml): use immutable releases
Fixes https://github.com/ansible-collections/partner-certification-checker/issues/71

Folks:
1. I've enabled immutable releases
2. We continue using v1 for backwards compatibility until we release v2.0.0. Then we freeze v1 and continue with specific immutable releases only. It shouldn't be a problem with for partners with dependabot we'll recommend in another PR https://github.com/ansible-collections/partner-certification-checker/pull/73


