### PR TITLE
feat(certification-reusable.yml): remove --skip-list sanity to validate ignore.txt files

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -175,7 +175,7 @@ jobs:
             echo "Changing directory based on collection root ${COLLECTION_ROOT}"
             cd "${COLLECTION_ROOT}"
           fi
-          ansible-lint --profile=production --skip-list sanity
+          ansible-lint --profile=production
 
   # Run sanity checks against the collection
   sanity:

--- a/changelogs/fragments/skip-sanity.yml
+++ b/changelogs/fragments/skip-sanity.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - certification-reusable.yml - remove --skip-list sanity argument from ansible-lint job not to skip ignore.txt files validation to check that entries in those ignore files are allowed.


### PR DESCRIPTION
##### SUMMARY
feat(certification-reusable.yml): remove --skip-list sanity to validate ignore.txt files

I don't remember why we added it originally. I think we should remove it not to skip ignore.txt files validation for allowed ignores + formatting.