### PR TITLE
Fix #86

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,10 @@
 ---
+profile: production
+
 exclude_paths:
-  # - .github/
-  - changelogs/
-  - tests/
-  - meta/
+  - tests/integration
+  - tests/unit
   - extensions/molecule
+  - changelogs
+  - docs
+  - .ansible

--- a/README.md
+++ b/README.md
@@ -48,18 +48,7 @@ Add the certification workflow to your collection repository.
 
 ## Add Ansible Lint configuration
 
-Add an [.ansible-lint](https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint) file to the root of your collection repository.
-
-Use `exclude_paths` for files and folders that are not part of the collection itself, such as `.github/`.
-
-Example:
-
-```yaml
----
-exclude_paths:
-  - .github/
-```
-
+Add an [.ansible-lint](https://raw.githubusercontent.com/ansible-collections/partner-certification-requirements/refs/heads/main/docs/.ansible-lint) file to the root of your collection repository.
 This prevents unrelated files from causing Ansible Lint failures.
 
 ## Keep the workflow updated

--- a/changelogs/fragments/86-ansible-lint-update.yml
+++ b/changelogs/fragments/86-ansible-lint-update.yml
@@ -1,0 +1,3 @@
+trivial:
+  - Update README.md .ansible-lint config file to reference from
+    the Partner Certification Requirements docsite.


### PR DESCRIPTION
##### SUMMARY

Update the `.ansible-lint` file to reference the authoritative copy at https://docs.ansible.com/projects/partner-certification-requirements/static-analysis/#example-ansible-lint-configuration.

Fixes #86 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
