### PR TITLE
Fix: Synchronize ansible-core and ansible-lint installation to prevent import errors

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -126,9 +126,6 @@ jobs:
         with:
           python-version: ${{ inputs.origin-python-version }}
 
-      - name: Install ansible-core
-        run: pip install ansible-core=="${CORE_VER}"
-
       # The default ansible-lint version is incompatible with ansible-core >= 2.19
       # because ansible.parsing.yaml.constructor was removed.
       # Use the ansible-core 2.19+ ansible-lint version for those runs.
@@ -140,8 +137,8 @@ jobs:
             echo "ANSIBLE_LINT_VER=${ANSIBLE_LINT_CORE_2_19_VER}" >> "${GITHUB_ENV}"
           fi
 
-      - name: Install ansible-lint
-        run: pip install ansible-lint=="${ANSIBLE_LINT_VER}"
+      - name: Install ansible-lint and ansible-core
+        run: pip install ansible-lint=="${ANSIBLE_LINT_VER}" ansible-core=="${CORE_VER}"
 
       - name: Install distlib required by ansible-galaxy build
         run: pip install "distlib>=0.3.9"

--- a/changelogs/fragments/93-sync-ansible-version-pins.yml
+++ b/changelogs/fragments/93-sync-ansible-version-pins.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - certification-reusable.yml - Install ansible-core and ansible-lint together in a single pip command to ensure version pins are synchronized and prevent import errors (https://github.com/ansible-collections/partner-certification-checker/issues/93).


### PR DESCRIPTION
##### SUMMARY

Fixes a race condition where ansible-core and ansible-lint are installed in separate pip commands, causing ansible-lint to potentially import an incompatible version of ansible-core. By installing both packages in a single pip command, pip can properly resolve dependencies and ensure version compatibility.

Fixes #93

This is a naive fix when it comes to version compatibility. I did limited testing locally with `ansible-lint=="24.12.2" ansible-core=="2.16"`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

GitHub workflow: certification-reusable
Jobs: 
- lint -> "Lint production"

##### ADDITIONAL INFORMATION

When using the reusable workflow with default settings, the lint job fails with:

```
ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor'
```

This occurs because ansible-core is installed first, then ansible-lint is installed separately. The ansible-lint version selection logic may pick a version that expects a different ansible-core API than what was installed.

The fix consolidates both installations into a single pip command, allowing pip to resolve the dependency tree atomically and prevent version mismatches.

See the error in https://github.com/ansible-collections/servicenow.itsm/actions/runs/31693130489/job/94424723324?pr=573