### PR TITLE
Fix: Update ansible-test-gh-action pin to 9cdbd323

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Perform sanity testing
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e # v1.17.0
+        uses: ansible-community/ansible-test-gh-action@9cdbd323f59530c0f43669f1168c8ef4a8c06d41
         with:
           ansible-core-version: ${{ matrix.ansible }}
           origin-python-version: ${{ inputs.origin-python-version }}

--- a/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
+++ b/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Update the ``ansible-community/ansible-test-gh-action`` action pin to commit ``9cdbd323f59530c0f43669f1168c8ef4a8c06d41`` (https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41).


### PR DESCRIPTION
## Summary

- Updates the `ansible-community/ansible-test-gh-action` action pin from `d3a8ec7a59694e25e210fcd44738910149537f0e` (v1.17.0) to `9cdbd323f59530c0f43669f1168c8ef4a8c06d41`, which pins all transitive actions to specific SHA-1 commits ([ansible-community/ansible-test-gh-action@9cdbd323](https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41))
- Adds a changelog fragment for this change

Partially fixes #92.

## Test plan

- [ ] Verify the `certification-reusable` workflow runs successfully with the updated pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)