### PR TITLE
chore(release): prepare 4.0.0 release

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Perform sanity testing
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e # v1.17.0
+        uses: ansible-community/ansible-test-gh-action@9cdbd323f59530c0f43669f1168c8ef4a8c06d41
         with:
           ansible-core-version: ${{ matrix.ansible }}
           origin-python-version: ${{ inputs.origin-python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Partner Certification Checker Release Notes
 v4.0.0
 ======
 
+Minor Changes
+-------------
+
+- Update the ``ansible-community/ansible-test-gh-action`` action pin to commit ``9cdbd323f59530c0f43669f1168c8ef4a8c06d41`` (https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41).
+
 Removed Features (previously deprecated)
 ----------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Partner Certification Checker Release Notes
 
 .. contents:: Topics
 
+v4.0.0
+======
+
+Removed Features (previously deprecated)
+----------------------------------------
+
+- Removed the self-maintained certification workflow variant so partners use the maintained reusable workflow and avoid version or configuration drift.
+
+Bugfixes
+--------
+
+- certification-reusable.yml - Add the missing distlib Python library for the build-import and lint jobs required to run `ansible-galaxy collection build`.
+- certification-reusable.yml - Install ansible-core and ansible-lint together in a single pip command to ensure version pins are synchronized and prevent import errors (https://github.com/ansible-collections/partner-certification-checker/issues/93).
+
 v3.0.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -139,6 +139,9 @@ releases:
       - certification-reusable.yml - Install ansible-core and ansible-lint together
         in a single pip command to ensure version pins are synchronized and prevent
         import errors (https://github.com/ansible-collections/partner-certification-checker/issues/93).
+      minor_changes:
+      - Update the ``ansible-community/ansible-test-gh-action`` action pin to commit
+        ``9cdbd323f59530c0f43669f1168c8ef4a8c06d41`` (https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41).
       removed_features:
       - Removed the self-maintained certification workflow variant so partners use
         the maintained reusable workflow and avoid version or configuration drift.
@@ -152,4 +155,5 @@ releases:
     - bump.yml
     - docs0.yml
     - readme-readability.yml
+    - update-ansible-test-gh-action-pin.yaml
     release_date: '2026-08-13'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -131,3 +131,25 @@ releases:
     - bump.yml
     - release.yml
     release_date: '2026-06-19'
+  4.0.0:
+    changes:
+      bugfixes:
+      - certification-reusable.yml - Add the missing distlib Python library for the
+        build-import and lint jobs required to run `ansible-galaxy collection build`.
+      - certification-reusable.yml - Install ansible-core and ansible-lint together
+        in a single pip command to ensure version pins are synchronized and prevent
+        import errors (https://github.com/ansible-collections/partner-certification-checker/issues/93).
+      removed_features:
+      - Removed the self-maintained certification workflow variant so partners use
+        the maintained reusable workflow and avoid version or configuration drift.
+    fragments:
+    - 68-centralize-workflow-versions.yml
+    - 84-remove-self-maintained-workflow.yml
+    - 86-ansible-lint-update.yml
+    - 89-update-codeowners.yml
+    - 93-sync-ansible-version-pins.yml
+    - add-distlib-python-dependency.yml
+    - bump.yml
+    - docs0.yml
+    - readme-readability.yml
+    release_date: '2026-08-13'

--- a/changelogs/fragments/68-centralize-workflow-versions.yml
+++ b/changelogs/fragments/68-centralize-workflow-versions.yml
@@ -1,2 +1,0 @@
-trivial:
-  - certification-reusable.yml - Centralize pinned tool versions at the workflow level for easier maintenance.

--- a/changelogs/fragments/84-remove-self-maintained-workflow.yml
+++ b/changelogs/fragments/84-remove-self-maintained-workflow.yml
@@ -1,2 +1,0 @@
-removed_features:
-  - Removed the self-maintained certification workflow variant so partners use the maintained reusable workflow and avoid version or configuration drift.

--- a/changelogs/fragments/86-ansible-lint-update.yml
+++ b/changelogs/fragments/86-ansible-lint-update.yml
@@ -1,3 +1,0 @@
-trivial:
-  - Update README.md .ansible-lint config file to reference from
-    the Partner Certification Requirements docsite.

--- a/changelogs/fragments/89-update-codeowners.yml
+++ b/changelogs/fragments/89-update-codeowners.yml
@@ -1,2 +1,0 @@
-trivial:
-  - .github/CODEOWNERS - add gundalow as a codeowner and remove oranod

--- a/changelogs/fragments/93-sync-ansible-version-pins.yml
+++ b/changelogs/fragments/93-sync-ansible-version-pins.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - certification-reusable.yml - Install ansible-core and ansible-lint together in a single pip command to ensure version pins are synchronized and prevent import errors (https://github.com/ansible-collections/partner-certification-checker/issues/93).

--- a/changelogs/fragments/add-distlib-python-dependency.yml
+++ b/changelogs/fragments/add-distlib-python-dependency.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - certification-reusable.yml - Add the missing distlib Python library for the build-import and lint jobs required to run `ansible-galaxy collection build`.

--- a/changelogs/fragments/bump.yml
+++ b/changelogs/fragments/bump.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Bump re-usable workflow version in certification.yml after release 3.0.0

--- a/changelogs/fragments/docs0.yml
+++ b/changelogs/fragments/docs0.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Mention Slack notification in RELEASING.md

--- a/changelogs/fragments/readme-readability.yml
+++ b/changelogs/fragments/readme-readability.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Improve README readability and setup guidance for the reusable certification workflow.

--- a/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
+++ b/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - Update the ``ansible-community/ansible-test-gh-action`` action pin to commit ``9cdbd323f59530c0f43669f1168c8ef4a8c06d41`` (https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41).

--- a/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
+++ b/changelogs/fragments/update-ansible-test-gh-action-pin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Update the ``ansible-community/ansible-test-gh-action`` action pin to commit ``9cdbd323f59530c0f43669f1168c8ef4a8c06d41`` (https://github.com/ansible-community/ansible-test-gh-action/commit/9cdbd323f59530c0f43669f1168c8ef4a8c06d41).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@
 
 namespace: "ansible"
 name: "certification"
-version: 3.0.0
+version: 4.0.0
 readme: README.md
 authors:
   - Ansible community and partner engineering team


### PR DESCRIPTION
## Summary

Release preparation for v4.0.0.

- Prepares the 4.0.0 release
- Updates the `ansible-community/ansible-test-gh-action` action pin to commit `9cdbd323f59530c0f43669f1168c8ef4a8c06d41` (cherry-picked from #95)
- Regenerates the changelog

## Test plan

- [ ] Review changelog entries are correct
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)