### PR TITLE
Add a collection-deps input to install collection dependencies

### DIFF
--- a/.github/workflows/certification-reusable.yml
+++ b/.github/workflows/certification-reusable.yml
@@ -41,6 +41,14 @@ on:
           repository).
         default: "."
         type: string
+      collection-deps:
+        description: >-
+          Specify collection dependencies to install during sanity checks.
+          The workflow does not automatically install dependencies from galaxy.yml
+          or requirements.yml. You can specify multiple collections separated
+          with spaces; for example, "kubernetes.core amazon.aws".
+        default: ""
+        type: string
       automation-hub:
         type: boolean
         description: >-
@@ -192,5 +200,6 @@ jobs:
           ansible-core-version: ${{ matrix.ansible }}
           origin-python-version: ${{ inputs.origin-python-version }}
           testing-type: sanity
+          test-deps: ${{ inputs.collection-deps }}
           collection-root: ${{ inputs.collection-root }}
           pull-request-change-detection: false

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -43,6 +43,7 @@ jobs:
     # with:
     #   ansible-core-version: '2.18.0'
     #   collection-root: 'ansible_collections/junipernetworks/junos'
+    #   collection-deps: 'kubernetes.core amazon.aws'
     #   automation-hub: true
     # Uncomment the lines below if you have 'automation-hub: true' and need to install collections from Red Hat Ansible Automation Hub.
     # This requires setting a repository secret called 'AH_TOKEN' which value contains a Red Hat Ansible Automation Hub token.

--- a/.github/workflows/test-certification-main-branch.yml
+++ b/.github/workflows/test-certification-main-branch.yml
@@ -40,3 +40,15 @@ jobs:
     uses: ./.github/workflows/certification-reusable.yml
     with:
       collection-root: "tests/fixtures/collection"
+
+  # Test installation of collection dependency
+  call-collection-deps:
+    uses: ./.github/workflows/certification-reusable.yml
+    with:
+      collection-deps: "kubernetes.core"
+
+  # Test installation of multiple collection dependencies
+  call-multiple-collection-deps:
+    uses: ./.github/workflows/certification-reusable.yml
+    with:
+      collection-deps: "kubernetes.core amazon.aws ansible.mcp"

--- a/changelogs/fragments/collection-deps-input.yml
+++ b/changelogs/fragments/collection-deps-input.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add a ``collection-deps`` input to install collections during ``ansible-test sanity`` checks. The input corresponds to the ``test-deps`` input in ``ansible-community/ansible-test-gh-action``.


### PR DESCRIPTION
##### SUMMARY

This change adds an input to allow the installation of collection dependencies during sanity test checks. This input is equivalent to the `test-deps` input provided by https://github.com/ansible-community/ansible-test-gh-action

Without this input, collection dependencies do not get installed and `ansible-test sanity` checks fail.

##### ISSUE TYPE

- Feature Pull Request

Tested in my fork of `community.okd`. Here are some details:

###### Run with `certification.yml` as of v4.0.0

https://github.com/oraNod/community.okd/actions/runs/32224430457

```
Install collection dependencies
Run >&2 echo Skipping installing the dependencies...
Skipping installing the dependencies...
```

You can see that `ansible-test sanity` checks fail. Errors trace back to `kubernetes.core` which is a collection dependency for community.okd.

###### Run with `collection-deps: "kubernetes.core`

https://github.com/oraNod/community.okd/actions/runs/32265105154

```    
Install collection dependencies

Run set -x; ~/.local/bin/ansible-galaxy collection install kubernetes.core -p .; set +x
  + /home/runner/.local/bin/ansible-galaxy collection install kubernetes.core -p .
  [WARNING]: The specified collections path '/home/runner/work/community.okd/community.okd' is not part of the configured Ansible collections paths '/home/runner/.ansible/collections:/usr/share/ansible/collections'. The installed collection will not be picked up in an Ansible run, unless within a playbook-adjacent collections directory.
  Starting galaxy collection install process
  Process install dependency map
  Starting collection install process
  Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/kubernetes-core-6.5.0.tar.gz to /home/runner/.ansible/tmp/ansible-local-2447fkeln3bl/tmp1qn7h1nj/kubernetes-core-6.5.0-jr54syp7
  Installing 'kubernetes.core:6.5.0' to '/home/runner/work/community.okd/community.okd/ansible_collections/kubernetes/core'
  kubernetes.core:6.5.0 was installed successfully
```

###### Run with `collection-deps: "kubernetes.core community.general amazon.aws"` test multiple collections

https://github.com/oraNod/community.okd/actions/runs/32265869343

```
Install collection dependencies

Run set -x; ~/.local/bin/ansible-galaxy collection install kubernetes.core community.general amazon.aws -p .; set +x
  + /home/runner/.local/bin/ansible-galaxy collection install kubernetes.core community.general amazon.aws -p .
  [WARNING]: The specified collections path '/home/runner/work/community.okd/community.okd' is not part of the configured Ansible collections paths '/home/runner/.ansible/collections:/usr/share/ansible/collections'. The installed collection will not be picked up in an Ansible run, unless within a playbook-adjacent collections directory.
  Starting galaxy collection install process
  Process install dependency map
  Starting collection install process
  Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/kubernetes-core-6.5.0.tar.gz to /home/runner/.ansible/tmp/ansible-local-2342p27k1dxn/tmpcps5r2cy/kubernetes-core-6.5.0-pqflsfl8
  Installing 'kubernetes.core:6.5.0' to '/home/runner/work/community.okd/community.okd/ansible_collections/kubernetes/core'
  kubernetes.core:6.5.0 was installed successfully
  Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-general-13.3.0.tar.gz to /home/runner/.ansible/tmp/ansible-local-2342p27k1dxn/tmpcps5r2cy/community-general-13.3.0-2ybphyko
  Installing 'community.general:13.3.0' to '/home/runner/work/community.okd/community.okd/ansible_collections/community/general'
  community.general:13.3.0 was installed successfully
  Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/amazon-aws-11.4.0.tar.gz to /home/runner/.ansible/tmp/ansible-local-2342p27k1dxn/tmpcps5r2cy/amazon-aws-11.4.0-r5gnbub2
  Installing 'amazon.aws:11.4.0' to '/home/runner/work/community.okd/community.okd/ansible_collections/amazon/aws'
  amazon.aws:11.4.0 was installed successfully
  Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-library_inventory_filtering_v1-1.1.5.tar.gz to /home/runner/.ansible/tmp/ansible-local-2342p27k1dxn/tmpcps5r2cy/community-library_inventory_filtering_v1-1.1.5-uev9fa4p
  Installing 'community.library_inventory_filtering_v1:1.1.5' to '/home/runner/work/community.okd/community.okd/ansible_collections/community/library_inventory_filtering_v1'
  community.library_inventory_filtering_v1:1.1.5 was installed successfully
```

###### Run with `collection-deps: ""` test default

https://github.com/oraNod/community.okd/actions/runs/32266424524

```
Install collection dependencies

Run >&2 echo Skipping installing the dependencies...
  Skipping installing the dependencies...
```